### PR TITLE
添加自动注册设备到i2c1

### DIFF
--- a/sensor_asair_aht10.c
+++ b/sensor_asair_aht10.c
@@ -147,3 +147,17 @@ __exit:
         aht10_deinit(temp_humi_dev);
     return -RT_ERROR;
 }
+
+int aht10_port(void)
+{
+    struct rt_sensor_config cfg;
+
+    cfg.intf.dev_name = "i2c1";
+    cfg.intf.arg = (void *)AHT10_ADDR;
+    cfg.irq_pin.pin = RT_PIN_NONE;
+
+    rt_hw_aht10_init("aht10", &cfg);
+
+    return 0;
+}
+INIT_APP_EXPORT(aht10_port);


### PR DESCRIPTION
自动注册设备后可以利用官方文档sensor设备的示例对注册到sensor框架的传感器进行控制。